### PR TITLE
Fix puzzle #2

### DIFF
--- a/HPSolver.py
+++ b/HPSolver.py
@@ -904,7 +904,7 @@ def hatch_puzzle(event=None):
                 data = str(entries[i][j].get()).strip()
                 values.append(data)
                 if not checkstop:
-                    if any(x in data for x in ['^', '+', '/']):
+                    if any(x in data for x in ['+', '/']):
                         puzzle = 4
                         checkstop = True
                     elif " " in data or "t" in data:


### PR DESCRIPTION
When I tried to solve puzzle 2, it got misidentified as puzzle 4 due to it containing the '^' character.